### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-displayNumber KEYWORD1
-displayErr KEYWORD2
-displayClear KEYWORD3
-setRefreshRate KEYWORD4
-displayVal KEYWORD5
+displayNumber	KEYWORD1
+displayErr	KEYWORD2
+displayClear	KEYWORD3
+setRefreshRate	KEYWORD4
+displayVal	KEYWORD5


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords