### PR TITLE
Use correct and valid KEYWORD_TOKENTYPEs in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-displayNumber	KEYWORD1
+displayNumber	KEYWORD2
 displayErr	KEYWORD2
-displayClear	KEYWORD3
-setRefreshRate	KEYWORD4
-displayVal	KEYWORD5
+displayClear	KEYWORD2
+setRefreshRate	KEYWORD2
+displayVal	KEYWORD2


### PR DESCRIPTION
Use of the undocumented KEYWORD4 has the unexpected result of coloring the keyword as an inline comment in Arduino IDE 1.6.4 and older. Use of the undocumented KEYWORD5 has the unexpected result of coloring the keyword as a hyperlink in Arduino IDE 1.6.4 and older.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype